### PR TITLE
Enable api response inspection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,12 @@
 				<version>${junit.version}</version>
 				<scope>test</scope>
 			</dependency>
+			<dependency>
+				<groupId>org.mockito</groupId>
+				<artifactId>mockito-all</artifactId>
+				<version>1.10.19</version>
+				<scope>test</scope>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 	<build>

--- a/scriba-analyser/pom.xml
+++ b/scriba-analyser/pom.xml
@@ -48,17 +48,22 @@
 			<artifactId>commons-lang3</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>log4j</groupId>
 			<artifactId>log4j</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-log4j12</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-all</artifactId>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 </project>

--- a/scriba-analyser/src/main/java/eu/codesketch/rest/scriba/analyser/domain/model/decorator/Descriptor.java
+++ b/scriba-analyser/src/main/java/eu/codesketch/rest/scriba/analyser/domain/model/decorator/Descriptor.java
@@ -20,6 +20,7 @@
 package eu.codesketch.rest.scriba.analyser.domain.model.decorator;
 
 import static eu.codesketch.rest.scriba.analyser.domain.model.decorator.Order.lookupOrder;
+import static java.lang.Boolean.FALSE;
 
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
@@ -27,19 +28,19 @@ import java.lang.reflect.Parameter;
 import java.util.Comparator;
 
 /**
- * Represent an annotation with and level that identifies where the annotation
- * is defined in the sub-class chain.
+ * Describes the context on which the introspection is executed.
  *
  * @author quirino.brizi
  * @since 29 Jan 2015
  *
  */
-public class Decorator {
+public class Descriptor {
 
     private int order;
     private int level;
     private java.lang.annotation.Annotation annotation;
     private AnnotatedElement annotatedElement;
+    private Boolean response;
 
     /**
      * Create a new wrapper for {@link java.lang.annotation.Annotation} setting
@@ -55,12 +56,13 @@ public class Decorator {
      *            a flag that indicates if the onnotation is place on method or
      *            not.
      */
-    public Decorator(int level, java.lang.annotation.Annotation annotation,
+    public Descriptor(int level, java.lang.annotation.Annotation annotation,
                     AnnotatedElement annotatedElement) {
         this.level = level;
         this.annotation = annotation;
         this.annotatedElement = annotatedElement;
         this.order = lookupOrder(annotation.annotationType());
+        this.response = FALSE;
     }
 
     public int level() {
@@ -69,6 +71,14 @@ public class Decorator {
 
     public int order() {
         return order;
+    }
+
+    public void setResponseInspected(Boolean response) {
+        this.response = response;
+    }
+
+    public Boolean isResponseInspected() {
+        return response;
     }
 
     public Boolean isOnMethod() {
@@ -118,11 +128,11 @@ public class Decorator {
         return builder.toString();
     }
 
-    public static Comparator<Decorator> decoratorOrderComparator() {
-        return new Comparator<Decorator>() {
+    public static Comparator<Descriptor> descriptorsOrderComparator() {
+        return new Comparator<Descriptor>() {
 
             @Override
-            public int compare(Decorator o1, Decorator o2) {
+            public int compare(Descriptor o1, Descriptor o2) {
                 return o2.order() - o1.order();
             }
         };

--- a/scriba-analyser/src/main/java/eu/codesketch/rest/scriba/analyser/domain/model/document/Document.java
+++ b/scriba-analyser/src/main/java/eu/codesketch/rest/scriba/analyser/domain/model/document/Document.java
@@ -53,7 +53,8 @@ public class Document {
     @JsonProperty private List<Parameter> pathParameters;
     @JsonProperty private List<Parameter> formParameters;
     @JsonProperty private List<Parameter> queryParameters;
-    @JsonProperty private Payload payload;
+    @JsonProperty private Payload requestPayload;
+    @JsonProperty private Payload responsePayload;
 
     private Document(String httpMethod) {
         this.httpMethod = lookupHttpMethod(httpMethod);
@@ -121,8 +122,13 @@ public class Document {
         return this;
     }
 
-    public Document withPayload(Payload payload) {
-        this.payload = payload;
+    public Document withRequestPayload(Payload payload) {
+        this.requestPayload = payload;
+        return this;
+    }
+
+    public Document withResponsePayload(Payload responsePayload) {
+        this.responsePayload = responsePayload;
         return this;
     }
 
@@ -137,7 +143,7 @@ public class Document {
                         .append(", description=").append(description).append(", path=")
                         .append(path).append(", consumes=").append(consumes).append(", produces=")
                         .append(produces).append(", pathParameters=").append(pathParameters)
-                        .append(", payload=").append(payload).append("]");
+                        .append(", payload=").append(requestPayload).append("]");
         return builder.toString();
     }
 }

--- a/scriba-analyser/src/main/java/eu/codesketch/rest/scriba/analyser/domain/model/document/DocumentBuilder.java
+++ b/scriba-analyser/src/main/java/eu/codesketch/rest/scriba/analyser/domain/model/document/DocumentBuilder.java
@@ -52,7 +52,8 @@ public class DocumentBuilder implements Cloneable {
     private Map<AnnotatedElement, Parameter> queryParameters;
     private List<String> consumables;
     private List<String> producible;
-    private Payload payload;
+    private Payload requestPayload;
+    private Payload responsePayload;
     private Name name;
     private Description description;
 
@@ -113,7 +114,7 @@ public class DocumentBuilder implements Cloneable {
         return this.pathParameters.containsKey(annotatedElement)
                         || this.formParameters.containsKey(annotatedElement)
                         || this.queryParameters.containsKey(annotatedElement)
-                        || this.payload.hasParameter(annotatedElement);
+                        || this.requestPayload.hasParameter(annotatedElement);
     }
 
     public Parameter getParameter(AnnotatedElement annotatedElement) {
@@ -130,7 +131,7 @@ public class DocumentBuilder implements Cloneable {
             if (null != answer) {
                 return answer;
             }
-            return this.payload.getParameter(annotatedElement);
+            return this.requestPayload.getParameter(annotatedElement);
         }
         throw new IllegalStateException(
                         String.format("requested annotated element %s has not been processed as a parameter, is the order for the Decorator correct??",
@@ -183,15 +184,22 @@ public class DocumentBuilder implements Cloneable {
     }
 
     public DocumentBuilder addPayload(Payload payload) {
-        this.payload = payload;
+        this.requestPayload = payload;
         return this;
     }
 
-    public Payload getOrCreatePayload() {
-        if (null == this.payload) {
-            this.payload = new Payload();
+    public Payload getOrCreateRequestPayload() {
+        if (null == this.requestPayload) {
+            this.requestPayload = new Payload();
         }
-        return this.payload;
+        return this.requestPayload;
+    }
+
+    public Payload getOrCreateResponsePayload() {
+        if (null == this.responsePayload) {
+            this.responsePayload = new Payload();
+        }
+        return this.responsePayload;
     }
 
     public Document build() {
@@ -201,7 +209,8 @@ public class DocumentBuilder implements Cloneable {
                         .withPathParameters(new ArrayList<>(this.pathParameters.values()))
                         .withFormParameters(new ArrayList<>(this.formParameters.values()))
                         .withQueryParameters(new ArrayList<>(this.queryParameters.values()))
-                        .withPayload(this.payload);
+                        .withRequestPayload(this.requestPayload)
+                        .withResponsePayload(this.responsePayload);
     }
 
     @Override
@@ -218,7 +227,7 @@ public class DocumentBuilder implements Cloneable {
     public String toString() {
         return "DocumentBuilder [httpMethod=" + httpMethod + ", pathSegments=" + pathSegments
                         + ", pathParameters=" + pathParameters + ", consumables=" + consumables
-                        + ", producible=" + producible + ", payload=" + payload + "]";
+                        + ", producible=" + producible + ", payload=" + requestPayload + "]";
     }
 
     private void setPathSegments(List<String> pathSegments) {

--- a/scriba-analyser/src/main/java/eu/codesketch/rest/scriba/analyser/domain/service/introspector/Introspector.java
+++ b/scriba-analyser/src/main/java/eu/codesketch/rest/scriba/analyser/domain/service/introspector/Introspector.java
@@ -19,7 +19,7 @@
  */
 package eu.codesketch.rest.scriba.analyser.domain.service.introspector;
 
-import eu.codesketch.rest.scriba.analyser.domain.model.decorator.Decorator;
+import eu.codesketch.rest.scriba.analyser.domain.model.decorator.Descriptor;
 import eu.codesketch.rest.scriba.analyser.domain.model.document.DocumentBuilder;
 
 /**
@@ -40,7 +40,7 @@ public interface Introspector {
      * @param annotation
      *            the annotation to introspect
      */
-    void instrospect(DocumentBuilder documentBuilder, Decorator annotation);
+    void instrospect(DocumentBuilder documentBuilder, Descriptor annotation);
 
     /**
      * Declare the type this introspector is made for.

--- a/scriba-analyser/src/main/java/eu/codesketch/rest/scriba/analyser/domain/service/introspector/Introspector.java
+++ b/scriba-analyser/src/main/java/eu/codesketch/rest/scriba/analyser/domain/service/introspector/Introspector.java
@@ -37,10 +37,10 @@ public interface Introspector {
      * 
      * @param documentBuilder
      *            the builder to populate
-     * @param annotation
-     *            the annotation to introspect
+     * @param descriptor
+     *            the introspect context
      */
-    void instrospect(DocumentBuilder documentBuilder, Descriptor annotation);
+    void instrospect(DocumentBuilder documentBuilder, Descriptor descriptor);
 
     /**
      * Declare the type this introspector is made for.

--- a/scriba-analyser/src/main/java/eu/codesketch/rest/scriba/analyser/domain/service/introspector/IntrospectorHelper.java
+++ b/scriba-analyser/src/main/java/eu/codesketch/rest/scriba/analyser/domain/service/introspector/IntrospectorHelper.java
@@ -1,0 +1,63 @@
+/**
+ * Scriba is a software library that aims to analyse REST interface and 
+ * produce machine readable documentation.
+ *
+ * Copyright (C) 2015  Quirino Brizi (quirino.brizi@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package eu.codesketch.rest.scriba.analyser.domain.service.introspector;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import eu.codesketch.rest.scriba.analyser.domain.model.decorator.Descriptor;
+import eu.codesketch.rest.scriba.analyser.domain.model.document.DocumentBuilder;
+
+/**
+ * A simple helper class that allow to reduce introspector related code
+ * duplication.
+ *
+ * @author quirino.brizi
+ * @since 3 Feb 2015
+ *
+ */
+public abstract class IntrospectorHelper {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(IntrospectorHelper.class);
+
+    private IntrospectorHelper() {
+    }
+
+    /**
+     * Execute introspection based on the provided descriptor.
+     * 
+     * @param introspectorManager
+     *            the introspector manager
+     * @param documentBuilder
+     *            the document builder to pass to the target
+     *            {@link Introspector}
+     * @param descriptor
+     *            the introspection descriptor.
+     */
+    public static void introspect(IntrospectorManager introspectorManager,
+                    DocumentBuilder documentBuilder, Descriptor descriptor) {
+        Introspector introspector = introspectorManager.introspector(descriptor.annotationType());
+        if (null != introspector) {
+            introspector.instrospect(documentBuilder, descriptor);
+        } else {
+            LOGGER.warn("unable instrospect {} as no valid introspector has been found", descriptor);
+        }
+    }
+}

--- a/scriba-analyser/src/main/java/eu/codesketch/rest/scriba/analyser/domain/service/introspector/RequestPayloadAnnotation.java
+++ b/scriba-analyser/src/main/java/eu/codesketch/rest/scriba/analyser/domain/service/introspector/RequestPayloadAnnotation.java
@@ -28,7 +28,7 @@ import java.lang.annotation.Annotation;
  * @since 29 Jan 2015
  *
  */
-public class BodyTypeAnnotation implements Annotation {
+public class RequestPayloadAnnotation implements Annotation {
 
     /*
      * (non-Javadoc)

--- a/scriba-analyser/src/main/java/eu/codesketch/rest/scriba/analyser/domain/service/introspector/jsr311/ConsumesAnnotationIntrospector.java
+++ b/scriba-analyser/src/main/java/eu/codesketch/rest/scriba/analyser/domain/service/introspector/jsr311/ConsumesAnnotationIntrospector.java
@@ -22,7 +22,7 @@ package eu.codesketch.rest.scriba.analyser.domain.service.introspector.jsr311;
 import javax.inject.Singleton;
 import javax.ws.rs.Consumes;
 
-import eu.codesketch.rest.scriba.analyser.domain.model.decorator.Decorator;
+import eu.codesketch.rest.scriba.analyser.domain.model.decorator.Descriptor;
 import eu.codesketch.rest.scriba.analyser.domain.model.document.DocumentBuilder;
 import eu.codesketch.rest.scriba.analyser.domain.service.introspector.Introspector;
 
@@ -49,7 +49,7 @@ public class ConsumesAnnotationIntrospector implements Introspector {
      * java.lang.Object, int)
      */
     @Override
-    public void instrospect(DocumentBuilder documentBuilder, Decorator annotation) {
+    public void instrospect(DocumentBuilder documentBuilder, Descriptor annotation) {
         Consumes consumes = annotation.getWrappedAnnotationAs(Consumes.class);
         documentBuilder.setOrReplaceConsumableTypes(consumes.value(), annotation.isOnMethod());
     }

--- a/scriba-analyser/src/main/java/eu/codesketch/rest/scriba/analyser/domain/service/introspector/jsr311/DeleteAnnotationIntrospector.java
+++ b/scriba-analyser/src/main/java/eu/codesketch/rest/scriba/analyser/domain/service/introspector/jsr311/DeleteAnnotationIntrospector.java
@@ -24,7 +24,7 @@ import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.HttpMethod;
 
-import eu.codesketch.rest.scriba.analyser.domain.model.decorator.Decorator;
+import eu.codesketch.rest.scriba.analyser.domain.model.decorator.Descriptor;
 import eu.codesketch.rest.scriba.analyser.domain.model.document.DocumentBuilder;
 import eu.codesketch.rest.scriba.analyser.domain.service.introspector.Introspector;
 
@@ -48,7 +48,7 @@ public class DeleteAnnotationIntrospector implements Introspector {
      * java.lang.Object, int)
      */
     @Override
-    public void instrospect(DocumentBuilder documentBuilder, Decorator annotation) {
+    public void instrospect(DocumentBuilder documentBuilder, Descriptor annotation) {
         documentBuilder.setHttpMethod(HttpMethod.DELETE);
     }
 

--- a/scriba-analyser/src/main/java/eu/codesketch/rest/scriba/analyser/domain/service/introspector/jsr311/FormParamAnnotationIntrospector.java
+++ b/scriba-analyser/src/main/java/eu/codesketch/rest/scriba/analyser/domain/service/introspector/jsr311/FormParamAnnotationIntrospector.java
@@ -25,7 +25,7 @@ import javax.ws.rs.DefaultValue;
 import javax.ws.rs.FormParam;
 
 import eu.codesketch.rest.scriba.analyser.domain.model.Parameter;
-import eu.codesketch.rest.scriba.analyser.domain.model.decorator.Decorator;
+import eu.codesketch.rest.scriba.analyser.domain.model.decorator.Descriptor;
 import eu.codesketch.rest.scriba.analyser.domain.model.document.DocumentBuilder;
 import eu.codesketch.rest.scriba.analyser.domain.service.introspector.Introspector;
 
@@ -52,7 +52,7 @@ public class FormParamAnnotationIntrospector implements Introspector {
      * java.lang.Object, int)
      */
     @Override
-    public void instrospect(DocumentBuilder documentBuilder, Decorator decorator) {
+    public void instrospect(DocumentBuilder documentBuilder, Descriptor decorator) {
         FormParam pathParam = decorator.getWrappedAnnotationAs(FormParam.class);
         java.lang.reflect.Parameter parameter = decorator
                         .annotatedElementAs(java.lang.reflect.Parameter.class);

--- a/scriba-analyser/src/main/java/eu/codesketch/rest/scriba/analyser/domain/service/introspector/jsr311/GetAnnotationIntrospector.java
+++ b/scriba-analyser/src/main/java/eu/codesketch/rest/scriba/analyser/domain/service/introspector/jsr311/GetAnnotationIntrospector.java
@@ -23,7 +23,7 @@ import javax.inject.Singleton;
 import javax.ws.rs.GET;
 import javax.ws.rs.HttpMethod;
 
-import eu.codesketch.rest.scriba.analyser.domain.model.decorator.Decorator;
+import eu.codesketch.rest.scriba.analyser.domain.model.decorator.Descriptor;
 import eu.codesketch.rest.scriba.analyser.domain.model.document.DocumentBuilder;
 import eu.codesketch.rest.scriba.analyser.domain.service.introspector.Introspector;
 
@@ -47,7 +47,7 @@ public class GetAnnotationIntrospector implements Introspector {
      * java.lang.Object, int)
      */
     @Override
-    public void instrospect(DocumentBuilder documentBuilder, Decorator annotation) {
+    public void instrospect(DocumentBuilder documentBuilder, Descriptor annotation) {
         documentBuilder.setHttpMethod(HttpMethod.GET);
     }
 

--- a/scriba-analyser/src/main/java/eu/codesketch/rest/scriba/analyser/domain/service/introspector/jsr311/HeadAnnotationIntrospector.java
+++ b/scriba-analyser/src/main/java/eu/codesketch/rest/scriba/analyser/domain/service/introspector/jsr311/HeadAnnotationIntrospector.java
@@ -24,7 +24,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.HEAD;
 import javax.ws.rs.HttpMethod;
 
-import eu.codesketch.rest.scriba.analyser.domain.model.decorator.Decorator;
+import eu.codesketch.rest.scriba.analyser.domain.model.decorator.Descriptor;
 import eu.codesketch.rest.scriba.analyser.domain.model.document.DocumentBuilder;
 import eu.codesketch.rest.scriba.analyser.domain.service.introspector.Introspector;
 
@@ -48,7 +48,7 @@ public class HeadAnnotationIntrospector implements Introspector {
      * java.lang.Object, int)
      */
     @Override
-    public void instrospect(DocumentBuilder documentBuilder, Decorator annotation) {
+    public void instrospect(DocumentBuilder documentBuilder, Descriptor annotation) {
         documentBuilder.setHttpMethod(HttpMethod.HEAD);
     }
 

--- a/scriba-analyser/src/main/java/eu/codesketch/rest/scriba/analyser/domain/service/introspector/jsr311/OptionsAnnotationIntrospector.java
+++ b/scriba-analyser/src/main/java/eu/codesketch/rest/scriba/analyser/domain/service/introspector/jsr311/OptionsAnnotationIntrospector.java
@@ -24,7 +24,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.HttpMethod;
 import javax.ws.rs.OPTIONS;
 
-import eu.codesketch.rest.scriba.analyser.domain.model.decorator.Decorator;
+import eu.codesketch.rest.scriba.analyser.domain.model.decorator.Descriptor;
 import eu.codesketch.rest.scriba.analyser.domain.model.document.DocumentBuilder;
 import eu.codesketch.rest.scriba.analyser.domain.service.introspector.Introspector;
 
@@ -48,7 +48,7 @@ public class OptionsAnnotationIntrospector implements Introspector {
      * java.lang.Object, int)
      */
     @Override
-    public void instrospect(DocumentBuilder documentBuilder, Decorator annotation) {
+    public void instrospect(DocumentBuilder documentBuilder, Descriptor annotation) {
         documentBuilder.setHttpMethod(HttpMethod.OPTIONS);
     }
 

--- a/scriba-analyser/src/main/java/eu/codesketch/rest/scriba/analyser/domain/service/introspector/jsr311/PathAnnotationIntrospector.java
+++ b/scriba-analyser/src/main/java/eu/codesketch/rest/scriba/analyser/domain/service/introspector/jsr311/PathAnnotationIntrospector.java
@@ -22,7 +22,7 @@ package eu.codesketch.rest.scriba.analyser.domain.service.introspector.jsr311;
 import javax.inject.Singleton;
 import javax.ws.rs.Path;
 
-import eu.codesketch.rest.scriba.analyser.domain.model.decorator.Decorator;
+import eu.codesketch.rest.scriba.analyser.domain.model.decorator.Descriptor;
 import eu.codesketch.rest.scriba.analyser.domain.model.document.DocumentBuilder;
 import eu.codesketch.rest.scriba.analyser.domain.service.introspector.Introspector;
 
@@ -46,7 +46,7 @@ public class PathAnnotationIntrospector implements Introspector {
      * java.lang.Object)
      */
     @Override
-    public void instrospect(DocumentBuilder documentBuilder, Decorator annotation) {
+    public void instrospect(DocumentBuilder documentBuilder, Descriptor annotation) {
         Path path = annotation.getWrappedAnnotationAs(Path.class);
         documentBuilder.addPathSegment(path.value(), annotation.level());
     }

--- a/scriba-analyser/src/main/java/eu/codesketch/rest/scriba/analyser/domain/service/introspector/jsr311/PathParamAnnotationIntrospector.java
+++ b/scriba-analyser/src/main/java/eu/codesketch/rest/scriba/analyser/domain/service/introspector/jsr311/PathParamAnnotationIntrospector.java
@@ -25,7 +25,7 @@ import javax.ws.rs.DefaultValue;
 import javax.ws.rs.PathParam;
 
 import eu.codesketch.rest.scriba.analyser.domain.model.Parameter;
-import eu.codesketch.rest.scriba.analyser.domain.model.decorator.Decorator;
+import eu.codesketch.rest.scriba.analyser.domain.model.decorator.Descriptor;
 import eu.codesketch.rest.scriba.analyser.domain.model.document.DocumentBuilder;
 import eu.codesketch.rest.scriba.analyser.domain.service.introspector.Introspector;
 
@@ -52,7 +52,7 @@ public class PathParamAnnotationIntrospector implements Introspector {
      * java.lang.Object, int)
      */
     @Override
-    public void instrospect(DocumentBuilder documentBuilder, Decorator decorator) {
+    public void instrospect(DocumentBuilder documentBuilder, Descriptor decorator) {
         PathParam pathParam = decorator.getWrappedAnnotationAs(PathParam.class);
         java.lang.reflect.Parameter parameter = decorator
                         .annotatedElementAs(java.lang.reflect.Parameter.class);

--- a/scriba-analyser/src/main/java/eu/codesketch/rest/scriba/analyser/domain/service/introspector/jsr311/PostAnnotationIntrospector.java
+++ b/scriba-analyser/src/main/java/eu/codesketch/rest/scriba/analyser/domain/service/introspector/jsr311/PostAnnotationIntrospector.java
@@ -23,7 +23,7 @@ import javax.inject.Singleton;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 
-import eu.codesketch.rest.scriba.analyser.domain.model.decorator.Decorator;
+import eu.codesketch.rest.scriba.analyser.domain.model.decorator.Descriptor;
 import eu.codesketch.rest.scriba.analyser.domain.model.document.DocumentBuilder;
 import eu.codesketch.rest.scriba.analyser.domain.service.introspector.Introspector;
 
@@ -47,7 +47,7 @@ public class PostAnnotationIntrospector implements Introspector {
      * java.lang.Object, int)
      */
     @Override
-    public void instrospect(DocumentBuilder documentBuilder, Decorator annotation) {
+    public void instrospect(DocumentBuilder documentBuilder, Descriptor annotation) {
         documentBuilder.setHttpMethod("POST");
     }
 

--- a/scriba-analyser/src/main/java/eu/codesketch/rest/scriba/analyser/domain/service/introspector/jsr311/ProducesAnnotationIntrospector.java
+++ b/scriba-analyser/src/main/java/eu/codesketch/rest/scriba/analyser/domain/service/introspector/jsr311/ProducesAnnotationIntrospector.java
@@ -23,7 +23,7 @@ import javax.inject.Singleton;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.Produces;
 
-import eu.codesketch.rest.scriba.analyser.domain.model.decorator.Decorator;
+import eu.codesketch.rest.scriba.analyser.domain.model.decorator.Descriptor;
 import eu.codesketch.rest.scriba.analyser.domain.model.document.DocumentBuilder;
 import eu.codesketch.rest.scriba.analyser.domain.service.introspector.Introspector;
 
@@ -50,7 +50,7 @@ public class ProducesAnnotationIntrospector implements Introspector {
      * java.lang.Object, int)
      */
     @Override
-    public void instrospect(DocumentBuilder documentBuilder, Decorator annotation) {
+    public void instrospect(DocumentBuilder documentBuilder, Descriptor annotation) {
         Produces produces = annotation.getWrappedAnnotationAs(Produces.class);
         documentBuilder.setOrReplaceProducibleTypes(produces.value(), annotation.isOnMethod());
     }

--- a/scriba-analyser/src/main/java/eu/codesketch/rest/scriba/analyser/domain/service/introspector/jsr311/PutAnnotationIntrospector.java
+++ b/scriba-analyser/src/main/java/eu/codesketch/rest/scriba/analyser/domain/service/introspector/jsr311/PutAnnotationIntrospector.java
@@ -24,7 +24,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.HttpMethod;
 import javax.ws.rs.PUT;
 
-import eu.codesketch.rest.scriba.analyser.domain.model.decorator.Decorator;
+import eu.codesketch.rest.scriba.analyser.domain.model.decorator.Descriptor;
 import eu.codesketch.rest.scriba.analyser.domain.model.document.DocumentBuilder;
 import eu.codesketch.rest.scriba.analyser.domain.service.introspector.Introspector;
 
@@ -48,7 +48,7 @@ public class PutAnnotationIntrospector implements Introspector {
      * java.lang.Object, int)
      */
     @Override
-    public void instrospect(DocumentBuilder documentBuilder, Decorator annotation) {
+    public void instrospect(DocumentBuilder documentBuilder, Descriptor annotation) {
         documentBuilder.setHttpMethod(HttpMethod.PUT);
     }
 

--- a/scriba-analyser/src/main/java/eu/codesketch/rest/scriba/analyser/domain/service/introspector/jsr311/QueryParamAnnotationIntrospector.java
+++ b/scriba-analyser/src/main/java/eu/codesketch/rest/scriba/analyser/domain/service/introspector/jsr311/QueryParamAnnotationIntrospector.java
@@ -25,7 +25,7 @@ import javax.ws.rs.DefaultValue;
 import javax.ws.rs.QueryParam;
 
 import eu.codesketch.rest.scriba.analyser.domain.model.Parameter;
-import eu.codesketch.rest.scriba.analyser.domain.model.decorator.Decorator;
+import eu.codesketch.rest.scriba.analyser.domain.model.decorator.Descriptor;
 import eu.codesketch.rest.scriba.analyser.domain.model.document.DocumentBuilder;
 import eu.codesketch.rest.scriba.analyser.domain.service.introspector.Introspector;
 
@@ -52,7 +52,7 @@ public class QueryParamAnnotationIntrospector implements Introspector {
      * java.lang.Object, int)
      */
     @Override
-    public void instrospect(DocumentBuilder documentBuilder, Decorator decorator) {
+    public void instrospect(DocumentBuilder documentBuilder, Descriptor decorator) {
         QueryParam queryParam = decorator.getWrappedAnnotationAs(QueryParam.class);
         java.lang.reflect.Parameter parameter = decorator
                         .annotatedElementAs(java.lang.reflect.Parameter.class);

--- a/scriba-analyser/src/main/java/eu/codesketch/rest/scriba/analyser/domain/service/introspector/jsr349/NotNullAnnotationIntrospector.java
+++ b/scriba-analyser/src/main/java/eu/codesketch/rest/scriba/analyser/domain/service/introspector/jsr349/NotNullAnnotationIntrospector.java
@@ -24,7 +24,7 @@ import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
 
 import eu.codesketch.rest.scriba.analyser.domain.model.Parameter;
-import eu.codesketch.rest.scriba.analyser.domain.model.decorator.Decorator;
+import eu.codesketch.rest.scriba.analyser.domain.model.decorator.Descriptor;
 import eu.codesketch.rest.scriba.analyser.domain.model.document.DocumentBuilder;
 import eu.codesketch.rest.scriba.analyser.domain.service.introspector.Introspector;
 
@@ -51,7 +51,7 @@ public class NotNullAnnotationIntrospector implements Introspector {
      * java.lang.Object, int)
      */
     @Override
-    public void instrospect(DocumentBuilder documentBuilder, Decorator decorator) {
+    public void instrospect(DocumentBuilder documentBuilder, Descriptor decorator) {
         Parameter parameter = documentBuilder.getParameter(decorator.annotatedElement());
         parameter.nullable(Boolean.FALSE).constraints("element must not be null");
     }

--- a/scriba-analyser/src/main/java/eu/codesketch/rest/scriba/analyser/domain/service/introspector/jsr349/PastAnnotationIntrospector.java
+++ b/scriba-analyser/src/main/java/eu/codesketch/rest/scriba/analyser/domain/service/introspector/jsr349/PastAnnotationIntrospector.java
@@ -24,7 +24,7 @@ import javax.validation.constraints.Past;
 import javax.ws.rs.Consumes;
 
 import eu.codesketch.rest.scriba.analyser.domain.model.Parameter;
-import eu.codesketch.rest.scriba.analyser.domain.model.decorator.Decorator;
+import eu.codesketch.rest.scriba.analyser.domain.model.decorator.Descriptor;
 import eu.codesketch.rest.scriba.analyser.domain.model.document.DocumentBuilder;
 import eu.codesketch.rest.scriba.analyser.domain.service.introspector.Introspector;
 
@@ -51,7 +51,7 @@ public class PastAnnotationIntrospector implements Introspector {
      * java.lang.Object, int)
      */
     @Override
-    public void instrospect(DocumentBuilder documentBuilder, Decorator decorator) {
+    public void instrospect(DocumentBuilder documentBuilder, Descriptor decorator) {
         Parameter parameter = documentBuilder.getParameter(decorator.annotatedElement());
         parameter.constraints("date must be in the past considering calendar based on the current timezone and the current locale.");
     }

--- a/scriba-analyser/src/main/java/eu/codesketch/rest/scriba/analyser/domain/service/introspector/jsr349/PatternAnnotationIntrospector.java
+++ b/scriba-analyser/src/main/java/eu/codesketch/rest/scriba/analyser/domain/service/introspector/jsr349/PatternAnnotationIntrospector.java
@@ -26,7 +26,7 @@ import javax.validation.constraints.Pattern;
 import javax.ws.rs.Consumes;
 
 import eu.codesketch.rest.scriba.analyser.domain.model.Parameter;
-import eu.codesketch.rest.scriba.analyser.domain.model.decorator.Decorator;
+import eu.codesketch.rest.scriba.analyser.domain.model.decorator.Descriptor;
 import eu.codesketch.rest.scriba.analyser.domain.model.document.DocumentBuilder;
 import eu.codesketch.rest.scriba.analyser.domain.service.introspector.Introspector;
 
@@ -53,7 +53,7 @@ public class PatternAnnotationIntrospector implements Introspector {
      * java.lang.Object, int)
      */
     @Override
-    public void instrospect(DocumentBuilder documentBuilder, Decorator decorator) {
+    public void instrospect(DocumentBuilder documentBuilder, Descriptor decorator) {
         Pattern pattern = decorator.getWrappedAnnotationAs(Pattern.class);
         Parameter parameter = documentBuilder.getParameter(decorator.annotatedElement());
         if (hasFlags(pattern)) {

--- a/scriba-analyser/src/main/java/eu/codesketch/rest/scriba/analyser/domain/service/introspector/jsr349/SizeAnnotationIntrospector.java
+++ b/scriba-analyser/src/main/java/eu/codesketch/rest/scriba/analyser/domain/service/introspector/jsr349/SizeAnnotationIntrospector.java
@@ -24,7 +24,7 @@ import javax.validation.constraints.Size;
 import javax.ws.rs.Consumes;
 
 import eu.codesketch.rest.scriba.analyser.domain.model.Parameter;
-import eu.codesketch.rest.scriba.analyser.domain.model.decorator.Decorator;
+import eu.codesketch.rest.scriba.analyser.domain.model.decorator.Descriptor;
 import eu.codesketch.rest.scriba.analyser.domain.model.document.DocumentBuilder;
 import eu.codesketch.rest.scriba.analyser.domain.service.introspector.Introspector;
 
@@ -51,7 +51,7 @@ public class SizeAnnotationIntrospector implements Introspector {
      * java.lang.Object, int)
      */
     @Override
-    public void instrospect(DocumentBuilder documentBuilder, Decorator decorator) {
+    public void instrospect(DocumentBuilder documentBuilder, Descriptor decorator) {
         Size size = decorator.getWrappedAnnotationAs(Size.class);
         Parameter parameter = documentBuilder.getParameter(decorator.annotatedElement());
         parameter.constraints(String.format(

--- a/scriba-analyser/src/main/java/eu/codesketch/rest/scriba/analyser/domain/service/introspector/scriba/ApiDescriptionAnnotationIntrospector.java
+++ b/scriba-analyser/src/main/java/eu/codesketch/rest/scriba/analyser/domain/service/introspector/scriba/ApiDescriptionAnnotationIntrospector.java
@@ -23,7 +23,7 @@ import javax.inject.Singleton;
 import javax.ws.rs.Consumes;
 
 import eu.codesketch.rest.scriba.analyser.domain.model.Description;
-import eu.codesketch.rest.scriba.analyser.domain.model.decorator.Decorator;
+import eu.codesketch.rest.scriba.analyser.domain.model.decorator.Descriptor;
 import eu.codesketch.rest.scriba.analyser.domain.model.document.DocumentBuilder;
 import eu.codesketch.rest.scriba.analyser.domain.service.introspector.Introspector;
 import eu.codesketch.rest.scriba.annotations.ApiDescription;
@@ -51,7 +51,7 @@ public class ApiDescriptionAnnotationIntrospector implements Introspector {
      * java.lang.Object, int)
      */
     @Override
-    public void instrospect(DocumentBuilder documentBuilder, Decorator decorator) {
+    public void instrospect(DocumentBuilder documentBuilder, Descriptor decorator) {
         ApiDescription apiDescription = decorator.getWrappedAnnotationAs(ApiDescription.class);
         documentBuilder.setDescription(new Description(apiDescription.value()));
     }

--- a/scriba-analyser/src/main/java/eu/codesketch/rest/scriba/analyser/domain/service/introspector/scriba/ApiNameAnnotationIntrospector.java
+++ b/scriba-analyser/src/main/java/eu/codesketch/rest/scriba/analyser/domain/service/introspector/scriba/ApiNameAnnotationIntrospector.java
@@ -23,7 +23,7 @@ import javax.inject.Singleton;
 import javax.ws.rs.Consumes;
 
 import eu.codesketch.rest.scriba.analyser.domain.model.Name;
-import eu.codesketch.rest.scriba.analyser.domain.model.decorator.Decorator;
+import eu.codesketch.rest.scriba.analyser.domain.model.decorator.Descriptor;
 import eu.codesketch.rest.scriba.analyser.domain.model.document.DocumentBuilder;
 import eu.codesketch.rest.scriba.analyser.domain.service.introspector.Introspector;
 import eu.codesketch.rest.scriba.annotations.ApiName;
@@ -51,7 +51,7 @@ public class ApiNameAnnotationIntrospector implements Introspector {
      * java.lang.Object, int)
      */
     @Override
-    public void instrospect(DocumentBuilder documentBuilder, Decorator decorator) {
+    public void instrospect(DocumentBuilder documentBuilder, Descriptor decorator) {
         ApiName apiName = decorator.getWrappedAnnotationAs(ApiName.class);
         documentBuilder.setName(new Name(apiName.value()));
     }

--- a/scriba-analyser/src/main/java/eu/codesketch/rest/scriba/analyser/domain/service/introspector/scriba/RequestPayloadAnnotationIntrospector.java
+++ b/scriba-analyser/src/main/java/eu/codesketch/rest/scriba/analyser/domain/service/introspector/scriba/RequestPayloadAnnotationIntrospector.java
@@ -19,14 +19,14 @@
  */
 package eu.codesketch.rest.scriba.analyser.domain.service.introspector.scriba;
 
-import static eu.codesketch.rest.scriba.analyser.domain.model.decorator.Decorator.decoratorOrderComparator;
-import static eu.codesketch.rest.scriba.analyser.infrastructure.helper.ReflectionHelper.getAllDeclaredDecorators;
+import static eu.codesketch.rest.scriba.analyser.domain.model.decorator.Descriptor.descriptorsOrderComparator;
+import static eu.codesketch.rest.scriba.analyser.domain.service.introspector.IntrospectorHelper.introspect;
+import static eu.codesketch.rest.scriba.analyser.infrastructure.helper.ReflectionHelper.extractAllDescriptors;
 import static eu.codesketch.rest.scriba.analyser.infrastructure.helper.ReflectionHelper.getFields;
+import static java.lang.Boolean.FALSE;
 
 import java.lang.reflect.Field;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 
 import javax.inject.Inject;
@@ -37,13 +37,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import eu.codesketch.rest.scriba.analyser.domain.model.Parameter;
-import eu.codesketch.rest.scriba.analyser.domain.model.decorator.Decorator;
+import eu.codesketch.rest.scriba.analyser.domain.model.decorator.Descriptor;
 import eu.codesketch.rest.scriba.analyser.domain.model.document.DocumentBuilder;
-import eu.codesketch.rest.scriba.analyser.domain.service.introspector.BodyTypeAnnotation;
 import eu.codesketch.rest.scriba.analyser.domain.service.introspector.Introspector;
 import eu.codesketch.rest.scriba.analyser.domain.service.introspector.IntrospectorManager;
-import eu.codesketch.rest.scriba.analyser.domain.service.introspector.impl.IntrospectorManagerImpl;
-import eu.codesketch.rest.scriba.analyser.domain.service.introspector.jackson.JsonPropertyAnnotationIntrospector;
+import eu.codesketch.rest.scriba.analyser.domain.service.introspector.RequestPayloadAnnotation;
 
 /**
  * Introspect {@link Consumes} annotation and populate the provided
@@ -57,17 +55,12 @@ import eu.codesketch.rest.scriba.analyser.domain.service.introspector.jackson.Js
  *
  */
 @Singleton
-public class BodyTypeAnnotationIntrospector implements Introspector {
+public class RequestPayloadAnnotationIntrospector implements Introspector {
 
     private static final Logger LOGGER = LoggerFactory
-                    .getLogger(BodyTypeAnnotationIntrospector.class);
+                    .getLogger(RequestPayloadAnnotationIntrospector.class);
 
     @Inject private IntrospectorManager introspectorManager;
-
-    public BodyTypeAnnotationIntrospector() {
-        introspectorManager = new IntrospectorManagerImpl(new HashSet<Introspector>(
-                        Arrays.asList(new JsonPropertyAnnotationIntrospector())));
-    }
 
     /*
      * (non-Javadoc)
@@ -78,20 +71,20 @@ public class BodyTypeAnnotationIntrospector implements Introspector {
      * java.lang.Object, int)
      */
     @Override
-    public void instrospect(DocumentBuilder documentBuilder, Decorator descriptor) {
+    public void instrospect(DocumentBuilder documentBuilder, Descriptor descriptor) {
         java.lang.reflect.Parameter parameter = descriptor
                         .annotatedElementAs(java.lang.reflect.Parameter.class);
         LOGGER.debug("processing annotated element of type {}", parameter.getClass());
         Class<?> parameterType = descriptor.getParameterType();
         if (parameterType.isPrimitive() || String.class.equals(parameterType)) {
-            documentBuilder.getOrCreatePayload().addParameter(descriptor.annotatedElement(),
+            documentBuilder.getOrCreateRequestPayload().addParameter(descriptor.annotatedElement(),
                             new Parameter(parameterType.getTypeName(), null));
         } else {
             doInspectBody(documentBuilder, parameterType);
-            if (documentBuilder.getOrCreatePayload().getParameters().isEmpty()) {
+            if (documentBuilder.getOrCreateRequestPayload().getParameters().isEmpty()) {
                 LOGGER.debug("no decorators has been found inspect fields");
                 for (Field field : getFields(parameterType)) {
-                    documentBuilder.getOrCreatePayload().addParameter(
+                    documentBuilder.getOrCreateRequestPayload().addParameter(
                                     descriptor.annotatedElement(),
                                     new Parameter(field.getType().getTypeName(), field.getName()));
                 }
@@ -105,25 +98,17 @@ public class BodyTypeAnnotationIntrospector implements Introspector {
      * @see eu.codesketch.rest.scriba.analyser.introspector.Introspector#type()
      */
     @Override
-    public Class<BodyTypeAnnotation> type() {
-        return BodyTypeAnnotation.class;
+    public Class<RequestPayloadAnnotation> type() {
+        return RequestPayloadAnnotation.class;
     }
 
     private void doInspectBody(DocumentBuilder documentBuilder, Class<?> body) {
-        List<Decorator> decorators = getAllDeclaredDecorators(body);
-        Collections.sort(decorators, decoratorOrderComparator());
-        for (Decorator decorator : decorators) {
-            introspect(documentBuilder, decorator);
+        List<Descriptor> descriptors = extractAllDescriptors(body);
+        Collections.sort(descriptors, descriptorsOrderComparator());
+        for (Descriptor descriptor : descriptors) {
+            descriptor.setResponseInspected(FALSE);
+            introspect(this.introspectorManager, documentBuilder, descriptor);
         }
     }
 
-    private void introspect(DocumentBuilder documentBuilder, Decorator decorator) {
-        Introspector introspector = this.introspectorManager.introspector(decorator
-                        .annotationType());
-        if (null != introspector) {
-            introspector.instrospect(documentBuilder, decorator);
-        } else {
-            LOGGER.warn("unable instrospect {} as no valid introspector has been found", decorator);
-        }
-    }
 }

--- a/scriba-analyser/src/main/java/eu/codesketch/rest/scriba/analyser/infrastructure/guice/ScribaInjector.java
+++ b/scriba-analyser/src/main/java/eu/codesketch/rest/scriba/analyser/infrastructure/guice/ScribaInjector.java
@@ -51,7 +51,8 @@ import eu.codesketch.rest.scriba.analyser.domain.service.introspector.jsr349.Pat
 import eu.codesketch.rest.scriba.analyser.domain.service.introspector.jsr349.SizeAnnotationIntrospector;
 import eu.codesketch.rest.scriba.analyser.domain.service.introspector.scriba.ApiDescriptionAnnotationIntrospector;
 import eu.codesketch.rest.scriba.analyser.domain.service.introspector.scriba.ApiNameAnnotationIntrospector;
-import eu.codesketch.rest.scriba.analyser.domain.service.introspector.scriba.BodyTypeAnnotationIntrospector;
+import eu.codesketch.rest.scriba.analyser.domain.service.introspector.scriba.ApiResponseAnnotationIntrospector;
+import eu.codesketch.rest.scriba.analyser.domain.service.introspector.scriba.RequestPayloadAnnotationIntrospector;
 
 /**
  * Injector configuration.
@@ -75,9 +76,10 @@ public class ScribaInjector extends AbstractModule {
             ProducesAnnotationIntrospector.class, PathParamAnnotationIntrospector.class,
             FormParamAnnotationIntrospector.class, QueryParamAnnotationIntrospector.class,
             // Internal
-            BodyTypeAnnotationIntrospector.class, 
+            RequestPayloadAnnotationIntrospector.class, 
             // Custom
             ApiDescriptionAnnotationIntrospector.class, ApiNameAnnotationIntrospector.class, 
+            ApiResponseAnnotationIntrospector.class,
             // JSR 349
             SizeAnnotationIntrospector.class, PatternAnnotationIntrospector.class, 
             PastAnnotationIntrospector.class, NotNullAnnotationIntrospector.class,

--- a/scriba-analyser/src/test/java/eu/codesketch/rest/scriba/analyser/application/impl/AnalyserServiceImplTest.java
+++ b/scriba-analyser/src/test/java/eu/codesketch/rest/scriba/analyser/application/impl/AnalyserServiceImplTest.java
@@ -37,6 +37,7 @@ import eu.codesketch.rest.scriba.analyser.domain.model.document.Document;
 import eu.codesketch.rest.scriba.analyser.infrastructure.guice.ScribaInjector;
 import eu.codesketch.rest.scriba.annotations.ApiDescription;
 import eu.codesketch.rest.scriba.annotations.ApiName;
+import eu.codesketch.rest.scriba.annotations.ApiResponse;
 
 public class AnalyserServiceImplTest {
 
@@ -69,8 +70,9 @@ public class AnalyserServiceImplTest {
         @Path("/books")
         @ApiName("List books")
         @ApiDescription("Retrieves all books")
-        public void list() {
-
+        @ApiResponse(type = BookMessage.class)
+        public Response list() {
+            return null;
         }
 
         @POST
@@ -97,8 +99,9 @@ public class AnalyserServiceImplTest {
         @Path("/books/{bookId}")
         @ApiName("Get book")
         @ApiDescription("Allows retrieve information about a book")
-        public void findById(@PathParam("bookId") Long bookId) {
-
+        @ApiResponse(type = BookMessage.class)
+        public Response findById(@PathParam("bookId") Long bookId) {
+            return null;
         }
 
         @DELETE
@@ -113,6 +116,7 @@ public class AnalyserServiceImplTest {
         @Path("/books/minimal")
         @ApiName("Create minimal book")
         @ApiDescription("Allows create a new book with only its name")
+        @ApiResponse(type = BookMessage.class)
         @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
         public Response addForm(
                         @Size(min = 1, max = 40) @Pattern(regexp = "[a-z]", flags = { Flag.CASE_INSENSITIVE }) @FormParam("name") String name,
@@ -123,17 +127,28 @@ public class AnalyserServiceImplTest {
 
     public static class Book {
         @JsonProperty private String author;
-        private String name;
+        private String title;
         @Past @JsonProperty private Date publicationDate;
 
-        @JsonProperty("name")
-        public String getName() {
-            return name;
+        @JsonProperty("title")
+        public String getTitle() {
+            return title;
         }
 
         @JsonProperty
-        public void setName(String name) {
-            this.name = name;
+        public void setTitle(String title) {
+            this.title = title;
+        }
+    }
+
+    public static class BookMessage {
+        @JsonProperty private String isbn;
+        @JsonProperty private String title;
+        @JsonProperty private String author;
+        @JsonProperty private Date publicationDate;
+
+        public String getIsbn() {
+            return isbn;
         }
     }
 }

--- a/scriba-analyser/src/test/java/eu/codesketch/rest/scriba/analyser/domain/service/introspector/IntrospectorHelperTest.java
+++ b/scriba-analyser/src/test/java/eu/codesketch/rest/scriba/analyser/domain/service/introspector/IntrospectorHelperTest.java
@@ -1,0 +1,33 @@
+package eu.codesketch.rest.scriba.analyser.domain.service.introspector;
+
+import static eu.codesketch.rest.scriba.analyser.domain.service.introspector.IntrospectorHelper.introspect;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+
+import eu.codesketch.rest.scriba.analyser.domain.model.decorator.Descriptor;
+import eu.codesketch.rest.scriba.analyser.domain.model.document.DocumentBuilder;
+
+public class IntrospectorHelperTest {
+
+    @Test
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public void testIntrospect() {
+        IntrospectorManager introspectorManager = mock(IntrospectorManager.class);
+        DocumentBuilder documentBuilder = mock(DocumentBuilder.class);
+        Descriptor descriptor = mock(Descriptor.class);
+        Introspector introspector = mock(Introspector.class);
+
+        Class clazz = RequestPayloadAnnotation.class;
+        when(descriptor.annotationType()).thenReturn(clazz);
+        when(introspectorManager.introspector(clazz)).thenReturn(introspector);
+        // act
+        introspect(introspectorManager, documentBuilder, descriptor);
+        // verify
+        verify(introspectorManager).introspector(clazz);
+        verify(descriptor).annotationType();
+        verify(introspector).instrospect(documentBuilder, descriptor);
+    }
+}

--- a/scriba-analyser/src/test/java/eu/codesketch/rest/scriba/analyser/domain/service/introspector/scriba/ApiResponseAnnotationIntrospectorTest.java
+++ b/scriba-analyser/src/test/java/eu/codesketch/rest/scriba/analyser/domain/service/introspector/scriba/ApiResponseAnnotationIntrospectorTest.java
@@ -1,0 +1,72 @@
+package eu.codesketch.rest.scriba.analyser.domain.service.introspector.scriba;
+
+import static java.lang.Boolean.FALSE;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.codehaus.jackson.annotate.JsonProperty;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import eu.codesketch.rest.scriba.analyser.domain.model.Parameter;
+import eu.codesketch.rest.scriba.analyser.domain.model.Payload;
+import eu.codesketch.rest.scriba.analyser.domain.model.decorator.Descriptor;
+import eu.codesketch.rest.scriba.analyser.domain.model.document.DocumentBuilder;
+import eu.codesketch.rest.scriba.analyser.domain.service.introspector.Introspector;
+import eu.codesketch.rest.scriba.analyser.domain.service.introspector.IntrospectorManager;
+import eu.codesketch.rest.scriba.annotations.ApiResponse;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ApiResponseAnnotationIntrospectorTest {
+
+    @Mock private IntrospectorManager introspectorManager;
+
+    @InjectMocks private ApiResponseAnnotationIntrospector testObj;
+
+    @Mock private DocumentBuilder documentBuilder;
+    @Mock private Descriptor descriptor;
+    @Mock private ApiResponse apiResponse;
+    @Mock private Introspector introspector;
+    @Mock private Payload payload;
+    @Mock private List<Parameter> parameterList;
+
+    @Test
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public void testInstrospect() {
+        Class annotationType = ApiResponse.class;
+        Class fieldAnnotationType = JsonProperty.class;
+        Class clazz = MessageResponse.class;
+
+        when(descriptor.getWrappedAnnotationAs(annotationType)).thenReturn(apiResponse);
+        when(descriptor.annotationType()).thenReturn(annotationType);
+        when(apiResponse.type()).thenReturn(clazz);
+        when(introspectorManager.introspector(fieldAnnotationType)).thenReturn(introspector);
+        when(documentBuilder.getOrCreateRequestPayload()).thenReturn(payload);
+        when(payload.getParameters()).thenReturn(parameterList);
+        when(parameterList.isEmpty()).thenReturn(FALSE);
+        // act
+        testObj.instrospect(documentBuilder, descriptor);
+        // verify
+        verify(descriptor).getWrappedAnnotationAs(annotationType);
+        verify(introspectorManager).introspector(fieldAnnotationType);
+        verify(introspector).instrospect(eq(documentBuilder), any(Descriptor.class));
+    }
+
+    @Test
+    public void testType() {
+        assertEquals(ApiResponse.class, testObj.type());
+    }
+
+    private static class MessageResponse {
+        @JsonProperty private String message;
+    }
+
+}

--- a/scriba-analyser/src/test/java/eu/codesketch/rest/scriba/analyser/infrastructure/helper/ReflectionHelperTest.java
+++ b/scriba-analyser/src/test/java/eu/codesketch/rest/scriba/analyser/infrastructure/helper/ReflectionHelperTest.java
@@ -20,10 +20,10 @@ public class ReflectionHelperTest {
     @Test
     public void testGetAnnotations_annotatedBaseClass() {
         // act
-        List<eu.codesketch.rest.scriba.analyser.domain.model.decorator.Decorator> annotations = getDecorators(AnnotatedBaseClass.class);
+        List<eu.codesketch.rest.scriba.analyser.domain.model.decorator.Descriptor> annotations = getDecorators(AnnotatedBaseClass.class);
         // assert
         assertEquals(1, annotations.size());
-        eu.codesketch.rest.scriba.analyser.domain.model.decorator.Decorator annotation = annotations.iterator().next();
+        eu.codesketch.rest.scriba.analyser.domain.model.decorator.Descriptor annotation = annotations.iterator().next();
         assertEquals(Path.class, annotation.annotationType());
         assertEquals(0, annotation.level());
     }
@@ -31,11 +31,11 @@ public class ReflectionHelperTest {
     @Test
     public void testGetAnnotations_annotatedClass() {
         // act
-        List<eu.codesketch.rest.scriba.analyser.domain.model.decorator.Decorator> annotations = getDecorators(AnnotatedClass.class);
+        List<eu.codesketch.rest.scriba.analyser.domain.model.decorator.Descriptor> annotations = getDecorators(AnnotatedClass.class);
         // assert
         assertEquals(2, annotations.size());
         int level = annotations.size() - 1;
-        for (eu.codesketch.rest.scriba.analyser.domain.model.decorator.Decorator annotation : annotations) {
+        for (eu.codesketch.rest.scriba.analyser.domain.model.decorator.Descriptor annotation : annotations) {
             assertEquals(Path.class, annotation.annotationType());
             assertEquals(level--, annotation.level());
             Path path = annotation.getWrappedAnnotationAs(Path.class);

--- a/scriba-annotations/src/main/java/eu/codesketch/rest/scriba/annotations/ApiResponse.java
+++ b/scriba-annotations/src/main/java/eu/codesketch/rest/scriba/annotations/ApiResponse.java
@@ -1,0 +1,30 @@
+package eu.codesketch.rest.scriba.annotations;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Allows define the return type for the API. This annotation is available at
+ * method level only.
+ * 
+ *
+ * @author quirino.brizi
+ * @since 2 Feb 2015
+ *
+ */
+@Documented
+@Target(METHOD)
+@Retention(RUNTIME)
+public @interface ApiResponse {
+
+    /**
+     * The return type.
+     * 
+     * @return the API return type.
+     */
+    Class<?> type();
+}


### PR DESCRIPTION
Api response inspection enabled using custom @ApiResponse annotation. Inspection is done for response fields only
